### PR TITLE
Specify that the clientURL is synonymous with endpoint

### DIFF
--- a/AI_1/computer-vision-translator/computer-vision.md
+++ b/AI_1/computer-vision-translator/computer-vision.md
@@ -19,6 +19,8 @@ COGSVCS_KEY=<key>
 
 Replace `<clienturl>` and `<key>` with the clienturl and key values you stored from the prior exercise. No quotes or other special characters are needed to contain the values.
 
+> **NOTE:** In Azure Cognitive Services, the `<clienturl>` is called the `Endpoint`.
+
 ## Add configuration code to app.py
 
 You have now subscribed to the Computer Vision API and stored the endpoint and API key. The next step is to modify the Contoso Travel site to load these values.


### PR DESCRIPTION
After I created my Cognitive Service Keys I was looking for a `key` and `clienturl` and was a little unsure if the `clienturl` was the same as the endpoint. Im hoping that adding a note will help save someone else a few minutes in the future if they're searching for a `clienturl` and can't find one.

<img width="709" alt="Screen Shot 2019-12-16 at 6 01 00 PM" src="https://user-images.githubusercontent.com/10103121/70950689-56cc4200-202f-11ea-9702-5f0155244779.png">
