### PR TITLE
Add /translate when testing the site

### DIFF
--- a/AI_1/computer-vision-translator/translator.md
+++ b/AI_1/computer-vision-translator/translator.md
@@ -109,7 +109,7 @@ We pass in the lines of code we wish to translate, which is stored in `messages`
 
 ## Test the site
 
-The last (and best?) step is to test our changes! Refresh the browser window from before (or navigate to **http://localhost:5000**). It should look something like this:
+The last (and best?) step is to test our changes! Refresh the browser window from before (or navigate to **http://localhost:5000/translate**). It should look something like this:
 
 ![Screenshot of updated page with language dropdown](../images/vision_added_translate.png)
 

--- a/AI_1/computer-vision-translator/translator.md
+++ b/AI_1/computer-vision-translator/translator.md
@@ -109,7 +109,7 @@ We pass in the lines of code we wish to translate, which is stored in `messages`
 
 ## Test the site
 
-The last (and best?) step is to test our changes! Refresh the browser window from before (or navigate to **http://localhost:5000/translate**). It should look something like this:
+The last (and best?) step is to test our changes! From the home page select `Translate a sign` or navigate to **http://localhost:5000/translate**. It should look something like this:
 
 ![Screenshot of updated page with language dropdown](../images/vision_added_translate.png)
 

--- a/AI_1/computer-vision-translator/translator.md
+++ b/AI_1/computer-vision-translator/translator.md
@@ -109,7 +109,7 @@ We pass in the lines of code we wish to translate, which is stored in `messages`
 
 ## Test the site
 
-The last (and best?) step is to test our changes! From the home page select `Translate a sign` or navigate to **http://localhost:5000/translate**. It should look something like this:
+The last (and best?) step is to test our changes! From the home page select **Translate a sign** or navigate to **http://localhost:5000/translate**. It should look something like this:
 
 ![Screenshot of updated page with language dropdown](../images/vision_added_translate.png)
 


### PR DESCRIPTION
The starter site must have changed a bit since these docs were added.

http://localhost:5000 now looks like this: 
<img width="1000" alt="Screen Shot 2019-12-16 at 6 25 37 PM" src="https://user-images.githubusercontent.com/10103121/70951468-795f5a80-2031-11ea-902c-a070dca26c8c.png">
So to test the changes made, it would be better to directly navigate to: http://localhost:5000/translate
<img width="1000" alt="Screen Shot 2019-12-16 at 6 25 23 PM" src="https://user-images.githubusercontent.com/10103121/70951509-9c8a0a00-2031-11ea-96df-e8eede3affd4.png">
