### PR TITLE
Change .iloc to .loc in exercise question

### DIFF
--- a/Data_Science_1/Full_Day/Instructor Materials/3-Pandas.ipynb
+++ b/Data_Science_1/Full_Day/Instructor Materials/3-Pandas.ipynb
@@ -308,7 +308,7 @@
         "trusted": true
       },
       "cell_type": "code",
-      "source": "# Can you think of a way to return the area of Japan without using .iloc?\n# Hint: Try putting the column index first.\n# Can you slice along these indices as well?\n",
+      "source": "# Can you think of a way to return the area of Japan without using .loc?\n# Hint: Try putting the column index first.\n# Can you slice along these indices as well?\n",
       "execution_count": null,
       "outputs": []
     },


### PR DESCRIPTION
<img width="937" alt="Screen Shot 2020-01-17 at 12 21 55 PM" src="https://user-images.githubusercontent.com/10103121/72643625-f8db9480-3923-11ea-90bb-59f289901edf.png">

Currently the exercise prompt shown above asks about returning the area without using **.iloc** but it looks like it should actually be asking without using **.loc** since that what is shown in the examples preceeding this question.

@daniel-dc-cd noticed this the other day when running the DS1 workshop