### PR TITLE
edits the markdown for the Images section

### DIFF
--- a/Web_Fundamentals_2/1_HTML/common_body_tags.md
+++ b/Web_Fundamentals_2/1_HTML/common_body_tags.md
@@ -44,7 +44,7 @@ Here's an example of how to use ```<p>``` tags:
  mperdiet eros, ac porta ligula ullamcorper in. Suspendisse nulla urna, facil
  isis non nunc ut, faucibus condimentum leo.
  </p>
-
+```
 
 ## Images
 


### PR DESCRIPTION
This change edits the "Images" section in the documentation which markdown was affected by the paragraph section above.