### PR TITLE
Adding missing package/installed app for Django sample

### DIFF
--- a/online-event-resources/web-development/django102/conference/settings.py
+++ b/online-event-resources/web-development/django102/conference/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'crispy_forms',
+    'crispy_bootstrap4'
 ]
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/online-event-resources/web-development/django102/requirements.txt
+++ b/online-event-resources/web-development/django102/requirements.txt
@@ -1,2 +1,3 @@
 django
 django-crispy-forms
+crispy-bootstrap4


### PR DESCRIPTION
Fixing requirements and settings for Django reactor (final solution) to correctly allow running the application. Currently it is missing the specification of `crispy_bootstrap4`, which leads to TemplateNotFound exceptions when trying to run the application as-is.

Reactor session: https://learn.microsoft.com/en-us/shows/reactor/build-a-custom-ui-with-django